### PR TITLE
Remove timeout on stdin

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -59,23 +59,15 @@
 
     function readStdin() {
       var text = ''
-        , timeoutToken
         , stdin = process.stdin
         ;
-      
+
       stdin.resume();
 
-      // how to tell piping vs waiting for user input?
-      timeoutToken = setTimeout(function () {
-        cb(new Error('no stdin data'));
-        stdin.pause();
-      }, 1000);
-
       stdin.on('data', function (chunk) {
-        clearTimeout(timeoutToken);
         text += chunk;
       });
-      
+
       stdin.on('end', function () {
         cb(null, text);
       });


### PR DESCRIPTION
I have a program that produces JSON but takes some time to start and I can't pipe it to json2yaml because of the timeout of 1s.

This patch removes the timeout.