### PR TITLE
Adding License information to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A commandline utility to convert JSON to YAML / YML",
   "keywords": ["yml", "yaml", "json", "cli", "util"],
   "version": "1.0.3",
+  "license": "Apache-2.0",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will make the license being used visible on npmjs.com, and downstream consumers via npm install, etc.